### PR TITLE
Added static linking and documentation for MinGW builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,5 +47,13 @@ target_link_options(phoenix-shared PRIVATE ${PXC_LINK_FLAGS})
 target_link_libraries(phoenix-shared phoenix)
 set_target_properties(phoenix-shared PROPERTIES DEBUG_POSTFIX "d" VERSION ${PROJECT_VERSION})
 
+if (MINGW)
+    # We need to "bake" standard C/C++ libraries into exe/DLL
+    # Otherwise we need to distribute libstdc++-6.dll into the same folder.
+    # If we don't do any of this, we'll get the following error (or a similar one):
+    # -> The procedure entry point _ZNKSt7codecvtlwc9_MbstatetE10do_unshiftERS0_PcS3_RS3_ could not be located in the dynamic link library [...]\build\test_lib.exe
+    target_link_options(phoenix-shared PUBLIC "-static-libstdc++")
+endif()
+
 install(TARGETS phoenix-shared ARCHIVE LIBRARY RUNTIME)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/phoenix" TYPE INCLUDE)

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ You will need:
 * CMake 3.10 or above
 * Git
 
+### default
 To build _phoenix-shared-interface_ from scratch, just open a terminal in a directory of your choice and run
 
 ```bash
@@ -33,3 +34,20 @@ cmake --build build
 ```
 
 You will find the built library in `build/`.
+
+
+### mingw
+
+If you want to build with MinGW on Windows, follow these instructions
+
+**setup**
+```sh
+choco install mingw
+```
+
+**build**  
+(tested mingw-w64 version: 12.2.0)
+```sh
+cmake -G "MinGW Makefiles" -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```


### PR DESCRIPTION
MinGW needs to have libstd++ statically linked into libphoenix-shared library.

This PR adds two features:
1. Add MinGW required linking on CMakeLists.txt
2. Add brief documentation how to build with MinGW on Windows