### PR TITLE
Aligned name and parameter ordering for Texture mipmap loadings.

### DIFF
--- a/include/phoenix/cffi/Texture.h
+++ b/include/phoenix/cffi/Texture.h
@@ -43,6 +43,6 @@ PXC_API void pxTexGetMeta(PxTexture const* tex,
                           uint32_t* mipmapCount,
                           uint32_t* averageColor);
 
-PXC_API uint8_t const* pxTexGetMipmap(PxTexture const* tex, uint32_t* length, uint32_t level, uint32_t* width, uint32_t* height);
-PXC_API uint8_t* pxTexGetDecompressedData(PxTexture const* tex, uint32_t level, uint32_t* size);
-PXC_API void pxTexFreeDecompressedData(uint8_t* data);
+PXC_API uint8_t const* pxTexGetMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height);
+uint8_t* pxTexGetDecompressedMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height);
+PXC_API void pxTexFreeDecompressedMipmap(uint8_t* data);

--- a/include/phoenix/cffi/Texture.h
+++ b/include/phoenix/cffi/Texture.h
@@ -44,5 +44,5 @@ PXC_API void pxTexGetMeta(PxTexture const* tex,
                           uint32_t* averageColor);
 
 PXC_API uint8_t const* pxTexGetMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height);
-uint8_t* pxTexGetDecompressedMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height);
+PXC_API uint8_t const* pxTexGetDecompressedMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height);
 PXC_API void pxTexFreeDecompressedMipmap(uint8_t* data);

--- a/include/phoenix/cffi/Texture.h
+++ b/include/phoenix/cffi/Texture.h
@@ -15,21 +15,21 @@ typedef struct PxInternal_Texture PxTexture;
 #endif
 
 typedef enum {
-    PxTexture_B8G8R8A8 = 0x0,
-    PxTexture_R8G8B8A8 = 0x1,
-    PxTexture_A8B8G8R8 = 0x2,
-    PxTexture_A8R8G8B8 = 0x3,
-    PxTexture_B8G8R8 = 0x4,
-    PxTexture_R8G8B8 = 0x5,
-    PxTexture_A4R4G4B4 = 0x6,
-    PxTexture_A1R5G5B5 = 0x7,
-    PxTexture_R5G6B5 = 0x8,
-    PxTexture_p8 = 0x9,
-    PxTexture_dxt1 = 0xA,
-    PxTexture_dxt2 = 0xB,
-    PxTexture_dxt3 = 0xC,
-    PxTexture_dxt4 = 0xD,
-    PxTexture_dxt5 = 0xE
+	PxTexture_B8G8R8A8 = 0x0,
+	PxTexture_R8G8B8A8 = 0x1,
+	PxTexture_A8B8G8R8 = 0x2,
+	PxTexture_A8R8G8B8 = 0x3,
+	PxTexture_B8G8R8 = 0x4,
+	PxTexture_R8G8B8 = 0x5,
+	PxTexture_A4R4G4B4 = 0x6,
+	PxTexture_A1R5G5B5 = 0x7,
+	PxTexture_R5G6B5 = 0x8,
+	PxTexture_p8 = 0x9,
+	PxTexture_dxt1 = 0xA,
+	PxTexture_dxt2 = 0xB,
+	PxTexture_dxt3 = 0xC,
+	PxTexture_dxt4 = 0xD,
+	PxTexture_dxt5 = 0xE
 } PxTextureFormat;
 
 PXC_API PxTexture* pxTexLoad(PxBuffer* buffer);
@@ -43,6 +43,16 @@ PXC_API void pxTexGetMeta(PxTexture const* tex,
                           uint32_t* mipmapCount,
                           uint32_t* averageColor);
 
-PXC_API uint8_t const* pxTexGetMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height);
-PXC_API uint8_t const* pxTexGetDecompressedMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height);
+PXC_API uint8_t const* pxTexGetMipmap(PxTexture const* tex, //
+                                      uint32_t level,
+                                      uint32_t* size,
+                                      uint32_t* width,
+                                      uint32_t* height);
+
+PXC_API uint8_t const* pxTexGetDecompressedMipmap(PxTexture const* tex, //
+                                                  uint32_t level,
+                                                  uint32_t* size,
+                                                  uint32_t* width,
+                                                  uint32_t* height);
+
 PXC_API void pxTexFreeDecompressedMipmap(uint8_t* data);

--- a/src/Texture.cc
+++ b/src/Texture.cc
@@ -53,7 +53,11 @@ uint8_t const* pxTexGetMipmap(PxTexture const* tex, uint32_t level, uint32_t* si
 	return data.data();
 }
 
-uint8_t const* pxTexGetDecompressedMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height) {
+uint8_t const* pxTexGetDecompressedMipmap(PxTexture const* tex, //
+                                          uint32_t level,
+                                          uint32_t* size,
+                                          uint32_t* width,
+                                          uint32_t* height) {
 	auto rgb = tex->as_rgba8(level);
 	*size = (uint32_t) rgb.size();
 	*width = tex->mipmap_width(level);

--- a/src/Texture.cc
+++ b/src/Texture.cc
@@ -53,7 +53,7 @@ uint8_t const* pxTexGetMipmap(PxTexture const* tex, uint32_t level, uint32_t* si
 	return data.data();
 }
 
-uint8_t* pxTexGetDecompressedMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height) {
+uint8_t const* pxTexGetDecompressedMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height) {
 	auto rgb = tex->as_rgba8(level);
 	*size = (uint32_t) rgb.size();
 	*width = tex->mipmap_width(level);

--- a/src/Texture.cc
+++ b/src/Texture.cc
@@ -45,18 +45,19 @@ void pxTexGetMeta(PxTexture const* tex,
 	*averageColor = tex->average_color();
 }
 
-uint8_t const*
-pxTexGetMipmap(PxTexture const* tex, uint32_t* length, uint32_t level, uint32_t* width, uint32_t* height) {
+uint8_t const* pxTexGetMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height) {
 	auto& data = tex->data(level);
-	*length = (uint32_t) data.size();
+	*size = (uint32_t) data.size();
 	*width = tex->mipmap_width(level);
 	*height = tex->mipmap_height(level);
 	return data.data();
 }
 
-uint8_t* pxTexGetDecompressedData(PxTexture const* tex, uint32_t level, uint32_t* size) {
+uint8_t* pxTexGetDecompressedMipmap(PxTexture const* tex, uint32_t level, uint32_t* size, uint32_t* width, uint32_t* height) {
 	auto rgb = tex->as_rgba8(level);
 	*size = (uint32_t) rgb.size();
+	*width = tex->mipmap_width(level);
+	*height = tex->mipmap_height(level);
 
 	// TODO: Performance!
 	auto* mem = static_cast<uint8_t*>(malloc(*size));
@@ -64,6 +65,6 @@ uint8_t* pxTexGetDecompressedData(PxTexture const* tex, uint32_t level, uint32_t
 	return mem;
 }
 
-void pxTexFreeDecompressedData(uint8_t* data) {
+void pxTexFreeDecompressedMipmap(uint8_t* data) {
 	free(data);
 }


### PR DESCRIPTION
Some code candy to align naming of different mipmap loading functions and parameter names+order.