### PR TITLE
pxVobGetRotation() - now marshalable within C#

### DIFF
--- a/include/phoenix/cffi/Api.h
+++ b/include/phoenix/cffi/Api.h
@@ -43,8 +43,16 @@ typedef struct {
 
 typedef struct {
 	/// \note Column major column order!
-	float m[3][3];
-} PxMat3;
+	float m00;
+	float m01;
+	float m02;
+	float m10;
+	float m11;
+	float m12;
+	float m20;
+	float m21;
+	float m22;
+} PxMat3x3;
 
 typedef struct {
 	PxVec3 min, max;

--- a/include/phoenix/cffi/World.h
+++ b/include/phoenix/cffi/World.h
@@ -117,6 +117,7 @@ PXC_API PxVob* pxWorldGetRootVob(PxWorld const* world, uint32_t i);
 
 PXC_API PxVobType pxVobGetType(PxVob const* vob);
 PXC_API uint32_t pxVobGetId(PxVob const* vob);
+PXC_API PxVec3 pxVobGetPosition(PxVob const* vob);
 PXC_API PxMat3 pxVobGetRotation(PxVob const* vob); ///< IMPORTANT: This matrix is column-major column order!
 PXC_API PxBool pxVobGetShowVisual(PxVob const* vob);
 PXC_API PxVobSpriteAlignment pxVobGetSpriteAlignment(PxVob const* vob);

--- a/include/phoenix/cffi/World.h
+++ b/include/phoenix/cffi/World.h
@@ -94,19 +94,6 @@ typedef enum {
 	PxVobVisualUnknown = 7,             ///< The VOb presents an unknown visual or no visual at all.
 } PxVobVisualType;
 
-typedef struct {
-	/// \note Column major column order!
-    float m00;
-    float m01;
-    float m02;
-    float m10;
-    float m11;
-    float m12;
-    float m20;
-    float m21;
-    float m22;
-} PxMat3x3;
-
 // TODO
 PXC_API PxWorld* pxWorldLoad(PxBuffer* buffer);
 PXC_API PxWorld* pxWorldLoadFromVdf(PxVdf const* vdf, char const* name);

--- a/include/phoenix/cffi/World.h
+++ b/include/phoenix/cffi/World.h
@@ -94,6 +94,19 @@ typedef enum {
 	PxVobVisualUnknown = 7,             ///< The VOb presents an unknown visual or no visual at all.
 } PxVobVisualType;
 
+typedef struct {
+	/// \note Column major column order!
+    float m00;
+    float m01;
+    float m02;
+    float m10;
+    float m11;
+    float m12;
+    float m20;
+    float m21;
+    float m22;
+} PxMat3x3;
+
 // TODO
 PXC_API PxWorld* pxWorldLoad(PxBuffer* buffer);
 PXC_API PxWorld* pxWorldLoadFromVdf(PxVdf const* vdf, char const* name);
@@ -118,7 +131,7 @@ PXC_API PxVob* pxWorldGetRootVob(PxWorld const* world, uint32_t i);
 PXC_API PxVobType pxVobGetType(PxVob const* vob);
 PXC_API uint32_t pxVobGetId(PxVob const* vob);
 PXC_API PxVec3 pxVobGetPosition(PxVob const* vob);
-PXC_API PxMat3 pxVobGetRotation(PxVob const* vob); ///< IMPORTANT: This matrix is column-major column order!
+PXC_API PxMat3x3 pxVobGetRotation(PxVob const* vob); ///< IMPORTANT: This matrix is column-major column order!
 PXC_API PxBool pxVobGetShowVisual(PxVob const* vob);
 PXC_API PxVobSpriteAlignment pxVobGetSpriteAlignment(PxVob const* vob);
 PXC_API PxBool pxVobGetCdStatic(PxVob const* vob);

--- a/src/World.cc
+++ b/src/World.cc
@@ -89,19 +89,19 @@ PxVec3 pxVobGetPosition(PxVob const* vob) {
 	return {pos.x, pos.y, pos.z};
 }
 
-PxMat3 pxVobGetRotation(PxVob const* vob) {
-	PxMat3 mat = {};
-
+PxMat3x3 pxVobGetRotation(PxVob const* vob) {
+	PxMat3x3 mat = {};
 	auto& rot = vob->rotation;
-	mat.m[0][0] = rot[0][0];
-	mat.m[0][1] = rot[0][1];
-	mat.m[0][2] = rot[0][2];
-	mat.m[1][0] = rot[1][0];
-	mat.m[1][1] = rot[1][1];
-	mat.m[1][2] = rot[1][2];
-	mat.m[2][0] = rot[2][0];
-	mat.m[2][1] = rot[2][1];
-	mat.m[2][2] = rot[2][2];
+
+    mat.m00 = rot[0][0];
+    mat.m01 = rot[0][1];
+    mat.m02 = rot[0][2];
+    mat.m10 = rot[1][0];
+    mat.m11 = rot[1][1];
+    mat.m12 = rot[1][2];
+    mat.m20 = rot[2][0];
+    mat.m21 = rot[2][1];
+    mat.m22 = rot[2][2];
 
 	return mat;
 }

--- a/src/World.cc
+++ b/src/World.cc
@@ -84,6 +84,11 @@ uint32_t pxVobGetId(PxVob const* vob) {
 	return vob->id;
 }
 
+PxVec3 pxVobGetPosition(PxVob const* vob) {
+	auto& pos = vob->position;
+	return {pos.x, pos.y, pos.z};
+}
+
 PxMat3 pxVobGetRotation(PxVob const* vob) {
 	PxMat3 mat = {};
 

--- a/src/World.cc
+++ b/src/World.cc
@@ -93,15 +93,15 @@ PxMat3x3 pxVobGetRotation(PxVob const* vob) {
 	PxMat3x3 mat = {};
 	auto& rot = vob->rotation;
 
-    mat.m00 = rot[0][0];
-    mat.m01 = rot[0][1];
-    mat.m02 = rot[0][2];
-    mat.m10 = rot[1][0];
-    mat.m11 = rot[1][1];
-    mat.m12 = rot[1][2];
-    mat.m20 = rot[2][0];
-    mat.m21 = rot[2][1];
-    mat.m22 = rot[2][2];
+	mat.m00 = rot[0][0];
+	mat.m01 = rot[0][1];
+	mat.m02 = rot[0][2];
+	mat.m10 = rot[1][0];
+	mat.m11 = rot[1][1];
+	mat.m12 = rot[1][2];
+	mat.m20 = rot[2][0];
+	mat.m21 = rot[2][1];
+	mat.m22 = rot[2][2];
 
 	return mat;
 }


### PR DESCRIPTION
Hi @lmichaelis 

I checked different options to get the multi-dimensional array returned to C#.
The only working approach was to use a struct which has 9 separate floats.

I recommend it this way. Feel free to rename the method to have another option exposing same method with differnt handling.

I recommend this approach, because:
1. It works on C# side ;-)
2. It is compile-time safe as the C#-endpoint implements it with the exact amount of elements. (If it would be an array, it would be without proper size limitation and could therefore cause errors at runtime).
3. The m00...m22 implementation also reflects the way C# handles Matrix (e.g. [3x2](https://learn.microsoft.com/en-us/dotnet/api/system.numerics.matrix3x2?view=net-8.0) and Unity as well within its Matrix4x4 (Image below)

![image](https://user-images.githubusercontent.com/120568393/233480756-00528811-0ad7-4a3d-9db1-4a24ed20f2b3.png)
