### PR TITLE
Added PxMat4x4 to ModelHierarchy. (complies with Api.h::PxMat3x3)

### DIFF
--- a/include/phoenix/cffi/Api.h
+++ b/include/phoenix/cffi/Api.h
@@ -55,6 +55,25 @@ typedef struct {
 } PxMat3x3;
 
 typedef struct {
+	float m00;
+	float m01;
+	float m02;
+	float m03;
+	float m10;
+	float m11;
+	float m12;
+	float m13;
+	float m20;
+	float m21;
+	float m22;
+	float m23;
+	float m30;
+	float m31;
+	float m32;
+	float m33;
+} PxMat4x4;
+
+typedef struct {
 	PxVec3 min, max;
 } PxAABB;
 

--- a/include/phoenix/cffi/ModelHierarchy.h
+++ b/include/phoenix/cffi/ModelHierarchy.h
@@ -24,4 +24,8 @@ PXC_API PxVec3 pxMdhGetRootTranslation(PxModelHierarchy const* mdh);
 PXC_API uint32_t pxMdhGetChecksum(PxModelHierarchy const* mdh);
 PXC_API uint32_t pxMdhGetNodeCount(PxModelHierarchy const* mdh);
 PXC_API void
-pxMdhGetNode(PxModelHierarchy const* mdh, uint32_t i, int16_t* parent, char const** name, PxMat4x4* transform);
+pxMdhGetNode(PxModelHierarchy const* mdh,
+                          uint32_t i,
+                          int16_t* parent,
+                          char const** name,
+                          PxMat4x4* transform);

--- a/include/phoenix/cffi/ModelHierarchy.h
+++ b/include/phoenix/cffi/ModelHierarchy.h
@@ -24,4 +24,4 @@ PXC_API PxVec3 pxMdhGetRootTranslation(PxModelHierarchy const* mdh);
 PXC_API uint32_t pxMdhGetChecksum(PxModelHierarchy const* mdh);
 PXC_API uint32_t pxMdhGetNodeCount(PxModelHierarchy const* mdh);
 PXC_API void
-pxMdhGetNode(PxModelHierarchy const* mdh, uint32_t i, int16_t* parent, char const** name /*, TODO: Node transform*/);
+pxMdhGetNode(PxModelHierarchy const* mdh, uint32_t i, int16_t* parent, char const** name, PxMat4x4* transform);

--- a/include/phoenix/cffi/ModelHierarchy.h
+++ b/include/phoenix/cffi/ModelHierarchy.h
@@ -24,8 +24,4 @@ PXC_API PxVec3 pxMdhGetRootTranslation(PxModelHierarchy const* mdh);
 PXC_API uint32_t pxMdhGetChecksum(PxModelHierarchy const* mdh);
 PXC_API uint32_t pxMdhGetNodeCount(PxModelHierarchy const* mdh);
 PXC_API void
-pxMdhGetNode(PxModelHierarchy const* mdh,
-                          uint32_t i,
-                          int16_t* parent,
-                          char const** name,
-                          PxMat4x4* transform);
+pxMdhGetNode(PxModelHierarchy const* mdh, uint32_t i, int16_t* parent, char const** name, PxMat4x4* transform);

--- a/src/ModelHierarchy.cc
+++ b/src/ModelHierarchy.cc
@@ -61,11 +61,7 @@ uint32_t pxMdhGetNodeCount(PxModelHierarchy const* mdh) {
 	return (uint32_t) mdh->nodes.size();
 }
 
-void pxMdhGetNode(PxModelHierarchy const* mdh,
-                  uint32_t i,
-                  int16_t* parent,
-                  char const** name,
-				  PxMat4x4* transform) {
+void pxMdhGetNode(PxModelHierarchy const* mdh, uint32_t i, int16_t* parent, char const** name, PxMat4x4* transform) {
 	auto& node = mdh->nodes[i];
 	*parent = node.parent_index;
 	*name = node.name.c_str();

--- a/src/ModelHierarchy.cc
+++ b/src/ModelHierarchy.cc
@@ -64,8 +64,25 @@ uint32_t pxMdhGetNodeCount(PxModelHierarchy const* mdh) {
 void pxMdhGetNode(PxModelHierarchy const* mdh,
                   uint32_t i,
                   int16_t* parent,
-                  char const** name /*, TODO: Node transform*/) {
+                  char const** name,
+				  PxMat4x4* transform) {
 	auto& node = mdh->nodes[i];
 	*parent = node.parent_index;
 	*name = node.name.c_str();
+	transform->m00 = node.transform[0][0];
+	transform->m01 = node.transform[0][1];
+	transform->m02 = node.transform[0][2];
+	transform->m03 = node.transform[0][3];
+	transform->m10 = node.transform[1][0];
+	transform->m11 = node.transform[1][1];
+	transform->m12 = node.transform[1][2];
+	transform->m13 = node.transform[1][3];
+	transform->m20 = node.transform[2][0];
+	transform->m21 = node.transform[2][1];
+	transform->m22 = node.transform[2][2];
+	transform->m23 = node.transform[2][3];
+	transform->m30 = node.transform[3][0];
+	transform->m31 = node.transform[3][1];
+	transform->m32 = node.transform[3][2];
+	transform->m33 = node.transform[3][3];
 }


### PR DESCRIPTION
Hint: I checked linting, but local execution of `clang-lint` didn't solve the problem. Sorry.