### PR TITLE
Added ID and SymbolIndex as VM-NPC exports.

### DIFF
--- a/include/phoenix/cffi/Vm.h
+++ b/include/phoenix/cffi/Vm.h
@@ -66,7 +66,7 @@ pxVmInstanceInitializeByName(PxVm* vm, char const* name, PxVmInstanceType type, 
 PXC_API void pxVmPrintStackTrace(PxVm const* vm);
 
 PXC_API int32_t pxVmInstanceNpcGetId(PxVmInstance const* instance);
-PXC_API const uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance);
+PXC_API uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance);
 PXC_API uint32_t pxVmInstanceNpcGetNameLength(PxVmInstance const* instance);
 PXC_API char const* pxVmInstanceNpcGetName(PxVmInstance const* instance, uint32_t i);
 PXC_API int32_t pxVmInstanceNpcGetRoutine(PxVmInstance const* instance);

--- a/include/phoenix/cffi/Vm.h
+++ b/include/phoenix/cffi/Vm.h
@@ -46,7 +46,6 @@ PXC_API PxVmInstance* pxVmGetGlobalOther(PxVm* vm);
 PXC_API PxVmInstance* pxVmGetGlobalVictim(PxVm* vm);
 PXC_API PxVmInstance* pxVmGetGlobalHero(PxVm* vm);
 PXC_API PxVmInstance* pxVmGetGlobalItem(PxVm* vm);
-PXC_API uint32_t pxVmInstanceGetSymbolIndex(PxVmInstance const* instance);
 
 PXC_API PxVmInstance* pxVmSetGlobalSelf(PxVm* vm, PxVmInstance* instance);
 PXC_API PxVmInstance* pxVmSetGlobalOther(PxVm* vm, PxVmInstance* instance);
@@ -63,6 +62,7 @@ PXC_API PxVmInstance*
 pxVmInstanceInitializeByIndex(PxVm* vm, uint32_t index, PxVmInstanceType type, PxVmInstance* existing);
 PXC_API PxVmInstance*
 pxVmInstanceInitializeByName(PxVm* vm, char const* name, PxVmInstanceType type, PxVmInstance* existing);
+PXC_API uint32_t pxVmInstanceGetSymbolIndex(PxVmInstance const* instance);
 
 PXC_API void pxVmPrintStackTrace(PxVm const* vm);
 

--- a/include/phoenix/cffi/Vm.h
+++ b/include/phoenix/cffi/Vm.h
@@ -46,6 +46,7 @@ PXC_API PxVmInstance* pxVmGetGlobalOther(PxVm* vm);
 PXC_API PxVmInstance* pxVmGetGlobalVictim(PxVm* vm);
 PXC_API PxVmInstance* pxVmGetGlobalHero(PxVm* vm);
 PXC_API PxVmInstance* pxVmGetGlobalItem(PxVm* vm);
+PXC_API uint32_t pxVmInstanceGetSymbolIndex(PxVmInstance const* instance);
 
 PXC_API PxVmInstance* pxVmSetGlobalSelf(PxVm* vm, PxVmInstance* instance);
 PXC_API PxVmInstance* pxVmSetGlobalOther(PxVm* vm, PxVmInstance* instance);

--- a/include/phoenix/cffi/Vm.h
+++ b/include/phoenix/cffi/Vm.h
@@ -65,8 +65,8 @@ pxVmInstanceInitializeByName(PxVm* vm, char const* name, PxVmInstanceType type, 
 
 PXC_API void pxVmPrintStackTrace(PxVm const* vm);
 
-PXC_API uint32_t pxVmInstanceNpcGetId(PxVmInstance const* instance);
-PXC_API uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance);
+PXC_API int32_t pxVmInstanceNpcGetId(PxVmInstance const* instance);
+PXC_API const uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance);
 PXC_API uint32_t pxVmInstanceNpcGetNameLength(PxVmInstance const* instance);
 PXC_API char const* pxVmInstanceNpcGetName(PxVmInstance const* instance, uint32_t i);
 PXC_API int32_t pxVmInstanceNpcGetRoutine(PxVmInstance const* instance);

--- a/include/phoenix/cffi/Vm.h
+++ b/include/phoenix/cffi/Vm.h
@@ -65,6 +65,8 @@ pxVmInstanceInitializeByName(PxVm* vm, char const* name, PxVmInstanceType type, 
 
 PXC_API void pxVmPrintStackTrace(PxVm const* vm);
 
+PXC_API uint32_t pxVmInstanceNpcGetId(PxVmInstance const* instance);
+PXC_API uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance);
 PXC_API uint32_t pxVmInstanceNpcGetNameLength(PxVmInstance const* instance);
 PXC_API char const* pxVmInstanceNpcGetName(PxVmInstance const* instance, uint32_t i);
 PXC_API int32_t pxVmInstanceNpcGetRoutine(PxVmInstance const* instance);

--- a/src/Vm.cc
+++ b/src/Vm.cc
@@ -402,6 +402,14 @@ void pxVmPrintStackTrace(PxVm const* vm) {
 	vm->vm.print_stack_trace();
 }
 
+uint32_t pxVmInstanceNpcGetId(PxVmInstance const* instance) {
+	return RCC(phoenix::c_npc, instance)->id;
+}
+
+uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance) {
+	return RCC(phoenix::c_npc, instance)->symbol_index();
+}
+
 uint32_t pxVmInstanceNpcGetNameLength(PxVmInstance const* instance) {
 	return RCC(phoenix::c_npc, instance)->name_count;
 }

--- a/src/Vm.cc
+++ b/src/Vm.cc
@@ -406,7 +406,7 @@ int32_t pxVmInstanceNpcGetId(PxVmInstance const* instance) {
 	return RCC(phoenix::c_npc, instance)->id;
 }
 
-const uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance) {
+uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance) {
 	return RCC(phoenix::c_npc, instance)->symbol_index();
 }
 

--- a/src/Vm.cc
+++ b/src/Vm.cc
@@ -178,6 +178,10 @@ PxVmInstance* pxVmGetGlobalItem(PxVm* vm) {
 	return vm->vm.global_item()->get_instance().get();
 }
 
+uint32_t pxVmInstanceGetSymbolIndex(PxVmInstance const* instance) {
+	return instance->symbol_index();
+}
+
 PxVmInstance* pxVmSetGlobalSelf(PxVm* vm, PxVmInstance* instance) {
 	auto* old = pxVmGetGlobalSelf(vm);
 
@@ -404,10 +408,6 @@ void pxVmPrintStackTrace(PxVm const* vm) {
 
 int32_t pxVmInstanceNpcGetId(PxVmInstance const* instance) {
 	return RCC(phoenix::c_npc, instance)->id;
-}
-
-uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance) {
-	return RCC(phoenix::c_npc, instance)->symbol_index();
 }
 
 uint32_t pxVmInstanceNpcGetNameLength(PxVmInstance const* instance) {

--- a/src/Vm.cc
+++ b/src/Vm.cc
@@ -178,10 +178,6 @@ PxVmInstance* pxVmGetGlobalItem(PxVm* vm) {
 	return vm->vm.global_item()->get_instance().get();
 }
 
-uint32_t pxVmInstanceGetSymbolIndex(PxVmInstance const* instance) {
-	return instance->symbol_index();
-}
-
 PxVmInstance* pxVmSetGlobalSelf(PxVm* vm, PxVmInstance* instance) {
 	auto* old = pxVmGetGlobalSelf(vm);
 
@@ -400,6 +396,10 @@ PxVmInstance* pxVmInstanceInitializeByName(PxVm* vm, char const* name, PxVmInsta
 	auto* sym = vm->vm.find_symbol_by_name(name);
 	if (sym == nullptr) return nullptr;
 	return pxInternalVmInstanceInitialize(vm, sym, type, existing);
+}
+
+uint32_t pxVmInstanceGetSymbolIndex(PxVmInstance const* instance) {
+	return instance->symbol_index();
 }
 
 void pxVmPrintStackTrace(PxVm const* vm) {

--- a/src/Vm.cc
+++ b/src/Vm.cc
@@ -402,11 +402,11 @@ void pxVmPrintStackTrace(PxVm const* vm) {
 	vm->vm.print_stack_trace();
 }
 
-uint32_t pxVmInstanceNpcGetId(PxVmInstance const* instance) {
+int32_t pxVmInstanceNpcGetId(PxVmInstance const* instance) {
 	return RCC(phoenix::c_npc, instance)->id;
 }
 
-uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance) {
+const uint32_t pxVmInstanceNpcGetSymbolIndex(PxVmInstance const* instance) {
 	return RCC(phoenix::c_npc, instance)->symbol_index();
 }
 


### PR DESCRIPTION
These methods were missing in the PxVm.cc file. Tested: I'm using them already for csharp-bridge.