### PR TITLE
Add buffer length and array functions

### DIFF
--- a/include/phoenix/cffi/Buffer.h
+++ b/include/phoenix/cffi/Buffer.h
@@ -15,3 +15,5 @@ typedef struct PxInternal_Buffer PxBuffer;
 PXC_API PxBuffer* pxBufferCreate(uint8_t const* bytes, uint64_t size);
 PXC_API PxBuffer* pxBufferMmap(char const* file);
 PXC_API void pxBufferDestroy(PxBuffer* buffer);
+PXC_API uint64_t pxBufferSize(PxBuffer* buffer);
+PXC_API std::byte* pxBufferArray(PxBuffer* buffer);

--- a/src/Buffer.cc
+++ b/src/Buffer.cc
@@ -60,3 +60,13 @@ PxBuffer* pxBufferMmap(char const* file) {
 void pxBufferDestroy(PxBuffer* buffer) {
 	delete buffer;
 }
+
+uint64_t pxBufferSize(PxBuffer* buffer) {
+	return buffer->limit();
+}
+
+std::byte* pxBufferArray(PxBuffer* buffer) {
+	std::byte* data = new std::byte[buffer->limit()];
+	buffer->get(data, buffer->limit());
+	return data;
+}


### PR DESCRIPTION
Small additions used in [GothicVR](https://github.com/GothicVRProject/GothicVR) to load audio from VDFS into unity