### PR TITLE
Feature/mdm attachments

### DIFF
--- a/include/phoenix/cffi/ModelMesh.h
+++ b/include/phoenix/cffi/ModelMesh.h
@@ -24,7 +24,9 @@ PXC_API void pxMdmDestroy(PxModelMesh* mdm);
 
 PXC_API uint32_t pxMdmGetMeshCount(PxModelMesh const* mdm);
 PXC_API PxSoftSkinMesh const* pxMdmGetMesh(PxModelMesh const* mdm, uint32_t i);
-PXC_API PxMultiResolutionMesh const* pxMdmGetAttachment(PxModelMesh const* mdm, char const* name);
+PXC_API uint32_t pxMdmGetAttachmentCount(PxModelMesh const* mdm);
+PXC_API char const* pxMdmGetAttachmentKey(PxModelMesh const* mdm, uint32_t index);
+PXC_API PxMultiResolutionMesh const* pxMdmGetAttachmentValue(PxModelMesh const* mdm, char const* name);
 PXC_API uint32_t pxMdmGetChecksum(PxModelMesh const* mdm);
 
 PXC_API PxMultiResolutionMesh const* pxSsmGetMesh(PxSoftSkinMesh const* ssm);

--- a/src/ModelMesh.cc
+++ b/src/ModelMesh.cc
@@ -40,11 +40,28 @@ PxSoftSkinMesh const* pxMdmGetMesh(PxModelMesh const* mdm, uint32_t i) {
 	return &mdm->meshes[i];
 }
 
-PxMultiResolutionMesh const* pxMdmGetAttachment(PxModelMesh const* mdm, char const* name) {
-	auto& attachments = mdm->attachments;
+uint32_t pxMdmGetAttachmentCount(PxModelMesh const* mdm) {
+	return mdm->attachments.size();
+}
 
+char const* pxMdmGetAttachmentKey(PxModelMesh const* mdm, uint32_t index) {
+	auto& attachments = mdm->attachments;
+    uint32_t currentIndex = 0;
+
+	for (auto i = attachments.begin(); i != attachments.end(); i++) {
+		if (currentIndex++ == index)
+			return i->first.c_str();
+	}
+
+	return nullptr;
+}
+
+PxMultiResolutionMesh const* pxMdmGetAttachmentValue(PxModelMesh const* mdm, char const* name) {
+	auto& attachments = mdm->attachments;
 	auto rv = attachments.find(name);
-	if (rv == attachments.end()) return nullptr;
+
+	if (rv == attachments.end())
+		return nullptr;
 
 	return &rv->second;
 }

--- a/src/ModelMesh.cc
+++ b/src/ModelMesh.cc
@@ -41,7 +41,7 @@ PxSoftSkinMesh const* pxMdmGetMesh(PxModelMesh const* mdm, uint32_t i) {
 }
 
 uint32_t pxMdmGetAttachmentCount(PxModelMesh const* mdm) {
-	return mdm->attachments.size();
+	return (uint32_t) mdm->attachments.size();
 }
 
 char const* pxMdmGetAttachmentKey(PxModelMesh const* mdm, uint32_t index) {

--- a/src/ModelMesh.cc
+++ b/src/ModelMesh.cc
@@ -46,11 +46,10 @@ uint32_t pxMdmGetAttachmentCount(PxModelMesh const* mdm) {
 
 char const* pxMdmGetAttachmentKey(PxModelMesh const* mdm, uint32_t index) {
 	auto& attachments = mdm->attachments;
-    uint32_t currentIndex = 0;
+	uint32_t currentIndex = 0;
 
-	for (auto i = attachments.begin(); i != attachments.end(); i++) {
-		if (currentIndex++ == index)
-			return i->first.c_str();
+	for (const auto& attachment : attachments) {
+		if (currentIndex++ == index) return attachment.first.c_str();
 	}
 
 	return nullptr;
@@ -60,8 +59,7 @@ PxMultiResolutionMesh const* pxMdmGetAttachmentValue(PxModelMesh const* mdm, cha
 	auto& attachments = mdm->attachments;
 	auto rv = attachments.find(name);
 
-	if (rv == attachments.end())
-		return nullptr;
+	if (rv == attachments.end()) return nullptr;
 
 	return &rv->second;
 }


### PR DESCRIPTION
Load all mdm attachments.

We need to loop through the unordered_map to fetch all it's keys. With the keys, we directly load values by string.